### PR TITLE
Changes needed for AimsApplyTransform and new APIs of aims::Resampler

### DIFF
--- a/src/libcartobase/config/cartobase_config.h
+++ b/src/libcartobase/config/cartobase_config.h
@@ -180,6 +180,7 @@ typedef unsigned int uint32_t;
 #define CARTO_OVERRIDE override
 #else
 #define CARTO_OVERRIDE
+#define static_assert(expr, msg)
 // in non-c++11 mode, replace unique_ptr with auto_ptr
 #include <memory>
 #define unique_ptr auto_ptr

--- a/src/libcartobase/config/cartobase_config.h
+++ b/src/libcartobase/config/cartobase_config.h
@@ -181,13 +181,8 @@ typedef unsigned int uint32_t;
 #else
 #define CARTO_OVERRIDE
 #define static_assert(expr, msg)
-// in non-c++11 mode, replace unique_ptr with auto_ptr
-#include <memory>
-#define unique_ptr auto_ptr
 #endif
 
 #include <cartobase/config/config.h>
 
 #endif // CARTOBASE_CONFIG_CARTOBASE_CONFIG_H
-
-

--- a/src/libcartobase/config/cartobase_config.h
+++ b/src/libcartobase/config/cartobase_config.h
@@ -181,6 +181,9 @@ typedef unsigned int uint32_t;
 #else
 #define CARTO_OVERRIDE
 #define static_assert(expr, msg)
+// in non-c++11 mode, replace unique_ptr with auto_ptr
+#include <memory>
+#define unique_ptr auto_ptr
 #endif
 
 #include <cartobase/config/config.h>

--- a/src/libcartobase/smart/rcptr.h
+++ b/src/libcartobase/smart/rcptr.h
@@ -315,14 +315,6 @@ public:
   {
     RefConstruction<T>::construct( this, r.release(), false );
   }
-
-  #if __cplusplus < 201703L
-  template< class U >
-  const_ref( std::auto_ptr<U>&& r )
-  {
-    RefConstruction<T>::construct( this, r.release(), false );
-  }
-  #endif
 #else
   template< class U >
   const_ref( std::auto_ptr<U> r )
@@ -484,13 +476,7 @@ public:
 
 #if __cplusplus >= 201103L
   template< class U >
-  ref( std::unique_ptr<U>&& r )
-    : const_ref<T>( std::move(r) ) {}
-
-  #if __cplusplus < 201703L
-  template< class U >
-  ref( std::auto_ptr<U>&& r ) : const_ref<T>( std::move(r) ) {}
-  #endif
+  ref( std::unique_ptr<U>&& r ) : const_ref<T>( std::move(r) ) {}
 #else
   template< class U >
   ref( std::auto_ptr<U> r ) : const_ref<T>( r ) {}
@@ -662,13 +648,7 @@ public:
 
 #if __cplusplus >= 201103L
   template< class U >
-  rc_ptr( std::unique_ptr<U>&& r )
-    : ref<T>( std::move(r) ) {}
-
-  #if __cplusplus < 201703L
-  template< class U >
-  rc_ptr( std::auto_ptr<U>&& r ) : ref<T>( std::move(r) ) {}
-  #endif
+  rc_ptr( std::unique_ptr<U>&& r ) : ref<T>( std::move(r) ) {}
 #else
   template< class U >
   rc_ptr( std::auto_ptr<U> r ) : ref<T>( r ) {}

--- a/src/libcartobase/smart/rcptr.h
+++ b/src/libcartobase/smart/rcptr.h
@@ -325,7 +325,7 @@ public:
   #endif
 #else
   template< class U >
-  const_ref( std::auto_ptr<U>& r )
+  const_ref( std::auto_ptr<U> r )
   {
     RefConstruction<T>::construct( this, r.release(), false );
   }
@@ -493,7 +493,7 @@ public:
   #endif
 #else
   template< class U >
-  ref( std::auto_ptr<U>& r ) : const_ref<T>( r ) {}
+  ref( std::auto_ptr<U> r ) : const_ref<T>( r ) {}
 #endif
 
   inline ref( const ref<T> &other ) : const_ref<T>( other ) {}
@@ -671,7 +671,7 @@ public:
   #endif
 #else
   template< class U >
-  rc_ptr( std::auto_ptr<U>& r ) : ref<T>( r ) {}
+  rc_ptr( std::auto_ptr<U> r ) : ref<T>( r ) {}
 #endif
 
   inline void reset( T *p = NULL )

--- a/src/libcartobase/smart/scopedptr.h
+++ b/src/libcartobase/smart/scopedptr.h
@@ -93,13 +93,6 @@ class scoped_ptr
     scoped_ptr( std::unique_ptr<U>&& r ) : pointee( r.release() )
     {
     }
-
-    #if __cplusplus < 201703L
-    template< class U >
-    scoped_ptr( std::auto_ptr<U>&& r ) : pointee( r.release() )
-    {
-    }
-    #endif
 #else
     template< class U >
     scoped_ptr( std::auto_ptr<U> r ) : pointee( r.release() )

--- a/src/libcartobase/smart/scopedptr.h
+++ b/src/libcartobase/smart/scopedptr.h
@@ -85,9 +85,27 @@ class scoped_ptr
     {
     }
 
-    explicit scoped_ptr( std::unique_ptr<T> p ) : pointee( p.release() )
+#if __cplusplus >= 201103L
+    // Only unique_ptr with the default deleter can be converted, because
+    // scoped_ptr does not support custom deleters (it calls the delete operator
+    // upon destruction, just like std::default_delete).
+    template< class U >
+    scoped_ptr( std::unique_ptr<U>&& r ) : pointee( r.release() )
     {
     }
+
+    #if __cplusplus < 201703L
+    template< class U >
+    scoped_ptr( std::auto_ptr<U>&& r ) : pointee( r.release() )
+    {
+    }
+    #endif
+#else
+    template< class U >
+    scoped_ptr( std::auto_ptr<U>& r ) : pointee( r.release() )
+    {
+    }
+#endif
 
     ~scoped_ptr()
     {
@@ -134,8 +152,16 @@ class scoped_ptr
 
   private:
 
-    scoped_ptr( const scoped_ptr& );
-    const scoped_ptr& operator=( const scoped_ptr& );
+    scoped_ptr( const scoped_ptr& )
+#if __cplusplus >= 201103L
+    = delete
+#endif
+      ;
+    const scoped_ptr& operator=( const scoped_ptr& )
+#if __cplusplus >= 201103L
+    = delete
+#endif
+      ;
 
     T* pointee;
 

--- a/src/libcartobase/smart/scopedptr.h
+++ b/src/libcartobase/smart/scopedptr.h
@@ -102,7 +102,7 @@ class scoped_ptr
     #endif
 #else
     template< class U >
-    scoped_ptr( std::auto_ptr<U>& r ) : pointee( r.release() )
+    scoped_ptr( std::auto_ptr<U> r ) : pointee( r.release() )
     {
     }
 #endif

--- a/src/libcartobase/type/datatypetraits.h
+++ b/src/libcartobase/type/datatypetraits.h
@@ -78,6 +78,12 @@ struct DataTypeTraits< T > \
   const bool carto::DataTypeTraits< T >::has_bool_conversion; \
   const unsigned int carto::DataTypeTraits< T >::channelcount; \
 
+#define DATA_TYPE_TRAITS_INSTANCIATE_TEMPLATE_SPECIALIZATION( T ) \
+  template<> const bool carto::DataTypeTraits< T >::is_scalar; \
+  template<> const bool carto::DataTypeTraits< T >::is_multichannel; \
+  template<> const bool carto::DataTypeTraits< T >::has_bool_conversion; \
+  template<> const unsigned int carto::DataTypeTraits< T >::channelcount; \
+
 
 namespace carto {
 

--- a/src/tests/cartoRcptr_test/rcptr_test.cc
+++ b/src/tests/cartoRcptr_test/rcptr_test.cc
@@ -145,13 +145,13 @@ int main()
 
   std::cout << "testing rc_ptr constructors from unique_ptr (RCObject)..." << std::endl;
   {
-    carto::rc_ptr<Foo> x = std::unique_ptr<Foo>( new Foo );
+    carto::rc_ptr<Foo> x(std::unique_ptr<Foo>( new Foo ));
     ASSERT( x );
     ASSERT( !(x == 0) );
   }
   std::cout << "testing rc_ptr constructors from unique_ptr..." << std::endl;
   {
-    carto::rc_ptr<Bar> x = std::unique_ptr<Bar>( new Bar );
+    carto::rc_ptr<Bar> x(std::unique_ptr<Bar>( new Bar ));
     ASSERT( x );
     ASSERT( !(x == 0) );
   }
@@ -159,13 +159,13 @@ int main()
 #if __cplusplus < 201703L
   std::cout << "testing rc_ptr constructors from auto_ptr (RCObject)..." << std::endl;
   {
-    carto::rc_ptr<Foo> x = std::auto_ptr<Foo>( new Foo );
+    carto::rc_ptr<Foo> x(std::auto_ptr<Foo>( new Foo ));
     ASSERT( x );
     ASSERT( !(x == 0) );
   }
   std::cout << "testing rc_ptr constructors from auto_ptr..." << std::endl;
   {
-    carto::rc_ptr<Bar> x = std::auto_ptr<Bar>( new Bar );
+    carto::rc_ptr<Bar> x(std::auto_ptr<Bar>( new Bar ));
     ASSERT( x );
     ASSERT( !(x == 0) );
   }

--- a/src/tests/cartoRcptr_test/rcptr_test.cc
+++ b/src/tests/cartoRcptr_test/rcptr_test.cc
@@ -143,7 +143,6 @@ int main()
     ASSERT( x1 == x2 );
   }
 
-#if __cplusplus >= 201103L
   std::cout << "testing rc_ptr constructors from std::unique_ptr (RCObject)..." << std::endl;
   {
     carto::rc_ptr<Foo> x(std::unique_ptr<Foo>( new Foo ));
@@ -156,20 +155,6 @@ int main()
     ASSERT( x );
     ASSERT( !(x == 0) );
   }
-#else
-  std::cout << "testing rc_ptr constructors from std::auto_ptr (RCObject)..." << std::endl;
-  {
-    carto::rc_ptr<Foo> x(std::auto_ptr<Foo>( new Foo ));
-    ASSERT( x );
-    ASSERT( !(x == 0) );
-  }
-  std::cout << "testing rc_ptr constructors from std::auto_ptr..." << std::endl;
-  {
-    carto::rc_ptr<Bar> x(std::auto_ptr<Bar>( new Bar ));
-    ASSERT( x );
-    ASSERT( !(x == 0) );
-  }
-#endif
 
   std::cout << "testing rc_ptr constructors (RCObject)..." << std::endl;
   {

--- a/src/tests/cartoRcptr_test/rcptr_test.cc
+++ b/src/tests/cartoRcptr_test/rcptr_test.cc
@@ -143,27 +143,27 @@ int main()
     ASSERT( x1 == x2 );
   }
 
-  std::cout << "testing rc_ptr constructors from unique_ptr (RCObject)..." << std::endl;
+#if __cplusplus >= 201103L
+  std::cout << "testing rc_ptr constructors from std::unique_ptr (RCObject)..." << std::endl;
   {
     carto::rc_ptr<Foo> x(std::unique_ptr<Foo>( new Foo ));
     ASSERT( x );
     ASSERT( !(x == 0) );
   }
-  std::cout << "testing rc_ptr constructors from unique_ptr..." << std::endl;
+  std::cout << "testing rc_ptr constructors from std::unique_ptr..." << std::endl;
   {
     carto::rc_ptr<Bar> x(std::unique_ptr<Bar>( new Bar ));
     ASSERT( x );
     ASSERT( !(x == 0) );
   }
-
-#if __cplusplus < 201703L
-  std::cout << "testing rc_ptr constructors from auto_ptr (RCObject)..." << std::endl;
+#else
+  std::cout << "testing rc_ptr constructors from std::auto_ptr (RCObject)..." << std::endl;
   {
     carto::rc_ptr<Foo> x(std::auto_ptr<Foo>( new Foo ));
     ASSERT( x );
     ASSERT( !(x == 0) );
   }
-  std::cout << "testing rc_ptr constructors from auto_ptr..." << std::endl;
+  std::cout << "testing rc_ptr constructors from std::auto_ptr..." << std::endl;
   {
     carto::rc_ptr<Bar> x(std::auto_ptr<Bar>( new Bar ));
     ASSERT( x );

--- a/src/tests/cartoRcptr_test/rcptr_test.cc
+++ b/src/tests/cartoRcptr_test/rcptr_test.cc
@@ -36,6 +36,7 @@
 #include <cartobase/smart/rcobject.h>
 #include <cartobase/exception/assert.h>
 #include <iostream>
+#include <memory>
 
 
 class Bar
@@ -125,24 +126,50 @@ int main()
 
   std::cout << "testing rc_ptr constructors (RCObject)..." << std::endl;
   {
-    carto::rc_ptr<Foo> x1 = carto::rc_ptr<Foo>( new Foo );
-    carto::rc_ptr<Foo> x2 = carto::rc_ptr<Foo>( new Foo );
-    ASSERT( x1 );
-    ASSERT( x2 );
-    ASSERT( !(x1 == 0) );
-    ASSERT( !(x2 == 0) );
-    ASSERT( x1 != x2 );
+    carto::rc_ptr<Foo> x1, x2;
+    ASSERT( !x1 );
+    ASSERT( !x2 );
+    ASSERT( x1 == 0 );
+    ASSERT( x2 == 0 );
+    ASSERT( x1 == x2 );
   }
   std::cout << "testing rc_ptr constructors..." << std::endl;
   {
-    carto::rc_ptr<Bar> x1 = carto::rc_ptr<Bar>( new Bar );
-    carto::rc_ptr<Bar> x2 = carto::rc_ptr<Bar>( new Bar );
-    ASSERT( x1 );
-    ASSERT( x2 );
-    ASSERT( !(x1 == 0) );
-    ASSERT( !(x2 == 0) );
-    ASSERT( x1 != x2 );
+    carto::rc_ptr<Bar> x1, x2;
+    ASSERT( !x1 );
+    ASSERT( !x2 );
+    ASSERT( x1 == 0 );
+    ASSERT( x2 == 0 );
+    ASSERT( x1 == x2 );
   }
+
+  std::cout << "testing rc_ptr constructors from unique_ptr (RCObject)..." << std::endl;
+  {
+    carto::rc_ptr<Foo> x = std::unique_ptr<Foo>( new Foo );
+    ASSERT( x );
+    ASSERT( !(x == 0) );
+  }
+  std::cout << "testing rc_ptr constructors from unique_ptr..." << std::endl;
+  {
+    carto::rc_ptr<Bar> x = std::unique_ptr<Bar>( new Bar );
+    ASSERT( x );
+    ASSERT( !(x == 0) );
+  }
+
+#if __cplusplus < 201703L
+  std::cout << "testing rc_ptr constructors from auto_ptr (RCObject)..." << std::endl;
+  {
+    carto::rc_ptr<Foo> x = std::auto_ptr<Foo>( new Foo );
+    ASSERT( x );
+    ASSERT( !(x == 0) );
+  }
+  std::cout << "testing rc_ptr constructors from auto_ptr..." << std::endl;
+  {
+    carto::rc_ptr<Bar> x = std::auto_ptr<Bar>( new Bar );
+    ASSERT( x );
+    ASSERT( !(x == 0) );
+  }
+#endif
 
   std::cout << "testing rc_ptr constructors (RCObject)..." << std::endl;
   {

--- a/src/tests/cartoScopedptr_test/scopedptr_test.cc
+++ b/src/tests/cartoScopedptr_test/scopedptr_test.cc
@@ -60,14 +60,14 @@ int main()
     ASSERT( x1 != x2 );
   }
 
-  std::cout << "testing scoped_ptr constructor from unique_ptr..." << std::endl;
+#if __cplusplus >= 201103L
+  std::cout << "testing scoped_ptr constructor from std::unique_ptr..." << std::endl;
   {
     carto::scoped_ptr<int> x( std::unique_ptr<int>( new int ) );
     ASSERT( x != 0 );
   }
-
-#if __cplusplus < 201703L
-  std::cout << "testing scoped_ptr constructor from auto_ptr..." << std::endl;
+#else
+  std::cout << "testing scoped_ptr constructor from std::auto_ptr..." << std::endl;
   {
     carto::scoped_ptr<int> x( std::auto_ptr<int>( new int ) );
     ASSERT( x != 0 );

--- a/src/tests/cartoScopedptr_test/scopedptr_test.cc
+++ b/src/tests/cartoScopedptr_test/scopedptr_test.cc
@@ -60,16 +60,17 @@ int main()
     ASSERT( x1 != x2 );
   }
 
-#if __cplusplus < 201103L
+  std::cout << "testing scoped_ptr constructor from unique_ptr..." << std::endl;
+  {
+    carto::scoped_ptr<int> x( std::unique_ptr<int>( new int ) );
+    ASSERT( x != 0 );
+  }
+
+#if __cplusplus < 201703L
   std::cout << "testing scoped_ptr constructor from auto_ptr..." << std::endl;
   {
-    std::auto_ptr<int> x1( new int );
-    ASSERT( x1.get() != 0 );
-    {
-      carto::scoped_ptr<int> x2( x1 );
-      ASSERT( x1.get() == 0 );
-      ASSERT( x2 != 0 );
-    }
+    carto::scoped_ptr<int> x( std::auto_ptr<int>( new int ) );
+    ASSERT( x != 0 );
   }
 #endif
 

--- a/src/tests/cartoScopedptr_test/scopedptr_test.cc
+++ b/src/tests/cartoScopedptr_test/scopedptr_test.cc
@@ -60,19 +60,11 @@ int main()
     ASSERT( x1 != x2 );
   }
 
-#if __cplusplus >= 201103L
   std::cout << "testing scoped_ptr constructor from std::unique_ptr..." << std::endl;
   {
     carto::scoped_ptr<int> x( std::unique_ptr<int>( new int ) );
     ASSERT( x != 0 );
   }
-#else
-  std::cout << "testing scoped_ptr constructor from std::auto_ptr..." << std::endl;
-  {
-    carto::scoped_ptr<int> x( std::auto_ptr<int>( new int ) );
-    ASSERT( x != 0 );
-  }
-#endif
 
   std::cout << "testing scoped_ptr::reset()..." << std::endl;
   {


### PR DESCRIPTION
These are cherry-picked commits from the `integration` branch, which are a prerequisite for merging the new command `AimsApplyTransform` and the revamped `aims::Resampler` APIs in [aims-free](https://github.com/brainvisa/aims-free).