### PR TITLE
Fix typography of vectors ((0, 1, 2) instead of (0 ,1 ,2))

### DIFF
--- a/src/libsoma-io/vector/vector.h
+++ b/src/libsoma-io/vector/vector.h
@@ -964,7 +964,7 @@ std::ostream& operator << ( std::ostream& out,const AimsVector<T,D>& thing)
 {
   out << '(';
   for (int d = 0; d < D-1 ; ++d)
-    out << thing.item(d) << " ,";
+    out << thing.item(d) << ", ";
   out << thing.item(D-1) << ')';
   return(out);
 }
@@ -976,7 +976,7 @@ std::ostream& operator << ( std::ostream& out,const AimsVector<char,D>& thing)
 {
   out << '(';
   for (int d = 0; d < D-1 ; ++d)
-    out << (int)thing.item(d) << " ,";
+    out << (int)thing.item(d) << ", ";
   out << (int)thing.item(D-1) << ')';
   return(out);
 }
@@ -988,7 +988,7 @@ std::ostream& operator << ( std::ostream& out,const AimsVector<byte,D>& thing)
 {
   out << '(';
   for (int d = 0; d < D-1 ; ++d)
-    out << (int)thing.item(d) << " ,";
+    out << (int)thing.item(d) << ", ";
   out << (int)thing.item(D-1) << ')';
   return(out);
 }


### PR DESCRIPTION
This is a minor thing, but it always hurt my eyes. This change might break tests and parsing, so I target the `integration` branch.