### PR TITLE
Look for shared path in Conda activated directory

### DIFF
--- a/src/libcartobase/config/paths.cc
+++ b/src/libcartobase/config/paths.cc
@@ -160,6 +160,9 @@ const string & Paths::globalShared()
     
     if( env_path )
       plist.push_back( env_path );
+    env_path = getenv( "CONDA_PREFIX" );
+    if( env_path )
+      plist.push_back( string(env_path) + FileUtil::separator() + "share"  );
     env_path = getenv( "SHFJ_SHARED_PATH" );
     if( env_path )
       plist.push_back( env_path );


### PR DESCRIPTION
A conda installation can be activated using `. <conda_install>/bin/activate`. This defines `CONDA_PREFIX` environment variable. I made this modification to use this variable to find share directory if it is defined.