### PR TITLE
Add Transformation::isDirect method

### DIFF
--- a/src/libsoma-io/transformation/affinetransformation3d_base.h
+++ b/src/libsoma-io/transformation/affinetransformation3d_base.h
@@ -111,6 +111,8 @@ namespace soma
     bool isIdentity() const CARTO_OVERRIDE;
     virtual void setToIdentity();
 
+    bool isDirect() const override;
+
     bool invertible() const CARTO_OVERRIDE;
     std::unique_ptr<AffineTransformationBase> inverse() const;
     std::unique_ptr<Transformation> getInverse() const CARTO_OVERRIDE;
@@ -255,8 +257,6 @@ namespace soma
     bool invertible() const CARTO_OVERRIDE;
     std::unique_ptr<Transformation> getInverse() const CARTO_OVERRIDE;
     virtual void scale( const Point3df& sizeFrom, const Point3df& sizeTo );
-    /// true if the transformation is direct, false if it changes orientation
-    bool isDirect() const;
 
     //Initialisation
     void setTranslation(Point3df trans);

--- a/src/libsoma-io/transformation/transformation.h
+++ b/src/libsoma-io/transformation/transformation.h
@@ -114,6 +114,9 @@ namespace soma
       throw std::logic_error("not implemented");
     }
 
+    /// true if the transformation is direct, false if it changes orientation
+    virtual bool isDirect() const = 0;
+
     /// vector arithmetics, as convenience static functions
     template <typename T>
     static std::vector<T> vadd( const std::vector<T> & v1,


### PR DESCRIPTION
In order to properly update the mesh normals when transforming a mesh, we must know for every transformation if it preserves orientation or inverts it.

Part of the fix for https://github.com/brainvisa/aims-free/issues/103

Beware that this PR goes along with https://github.com/brainvisa/aims-free/pull/104, both must be merged simultenaously or builds will break.