### PR TITLE
Remove LGTM.com configuration file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,2 +1,0 @@
-queries:
-  - exclude: py/weak-sensitive-data-hashing


### PR DESCRIPTION
LGTM.com has been deprecated and replaced by GitHub code analysis:
https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/